### PR TITLE
Add themes, asset pipeline, and collection pagination features

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .fingerprint = 0x6258ab6458a3c4a3,
     .dependencies = .{
         .httpz = .{
-            .url = "git+https://github.com/karlseguin/http.zig?ref=dev#b1896f4b0bd30deb0351039b1ba470c9041f4117",
-            .hash = "httpz-0.0.0-PNVzrE-8BgCUEVpFtYaUOFrWMqXHBu95eyIYRkXbyriy",
+            .url = "git+https://github.com/karlseguin/http.zig?ref=zig-0.14#ef50c6878c3c512786e3311df657eb425b87ba91",
+            .hash = "httpz-0.0.0-PNVzrAvCBgDPm4lE3vCQekPyCKAE2TIsbxly-GeS1_gl",
         },
         .custom_test_runner = .{ .path = "./modules/custom-test-runner" },
         .bulma = .{ .path = "./modules/bulma" },

--- a/src/Cli.zig
+++ b/src/Cli.zig
@@ -27,6 +27,7 @@ pub const Command = union(enum) {
         },
         out_dir: []const u8 = "build",
         url_prefix: ?[]const u8 = null,
+        theme: ?[]const u8 = null,
     };
     pub const Init = struct {
         site_root: union(enum) {
@@ -41,6 +42,7 @@ pub const Command = union(enum) {
         },
         out_dir: []const u8 = "build",
         url_prefix: ?[]const u8 = null,
+        theme: ?[]const u8 = null,
     };
 
     /// Assumes the exe name has already been consumed in the iterator
@@ -64,6 +66,7 @@ pub const Command = union(enum) {
         var site_root: ?[]const u8 = null;
         var out_dir: ?[]const u8 = null;
         var url_prefix: ?[]const u8 = null;
+        var theme: ?[]const u8 = null;
 
         while (args.next()) |arg| {
             if (mem.eql(u8, arg, "-o")) {
@@ -72,6 +75,9 @@ pub const Command = union(enum) {
             } else if (mem.eql(u8, arg, "-p")) {
                 if (url_prefix != null) return error.TooManyArguments;
                 url_prefix = args.next() orelse return error.MissingUrlPrefix;
+            } else if (mem.eql(u8, arg, "-t")) {
+                if (theme != null) return error.TooManyArguments;
+                theme = args.next() orelse return error.MissingTheme;
             } else {
                 if (site_root != null) return error.TooManyArguments;
                 site_root = arg;
@@ -87,6 +93,7 @@ pub const Command = union(enum) {
         };
         if (out_dir) |path| build.out_dir = path;
         if (url_prefix) |prefix| build.url_prefix = prefix;
+        if (theme) |value| build.theme = value;
         return .{ .build = build };
     }
 
@@ -94,6 +101,7 @@ pub const Command = union(enum) {
         var site_root: ?[]const u8 = null;
         var out_dir: ?[]const u8 = null;
         var url_prefix: ?[]const u8 = null;
+        var theme: ?[]const u8 = null;
 
         while (args.next()) |arg| {
             if (mem.eql(u8, arg, "-o")) {
@@ -102,6 +110,9 @@ pub const Command = union(enum) {
             } else if (mem.eql(u8, arg, "-p")) {
                 if (url_prefix != null) return error.TooManyArguments;
                 url_prefix = args.next() orelse return error.MissingUrlPrefix;
+            } else if (mem.eql(u8, arg, "-t")) {
+                if (theme != null) return error.TooManyArguments;
+                theme = args.next() orelse return error.MissingTheme;
             } else {
                 if (site_root != null) return error.TooManyArguments;
                 site_root = arg;
@@ -116,6 +127,7 @@ pub const Command = union(enum) {
             .{ .relative = site_root.? } };
         if (out_dir) |path| preview.out_dir = path;
         if (url_prefix) |prefix| preview.url_prefix = prefix;
+        if (theme) |value| preview.theme = value;
         return .{ .preview = preview };
     }
 
@@ -154,7 +166,8 @@ const standard_help =
     \\    goku -h
     \\    goku init [<site_root>]
     \\    goku build <site_root> -o <out_dir> [-p <url_prefix>]
-    \\    goku preview <site_root> -o <out_dir> [-p <url_prefix>]
+    \\    goku preview <site_root> -o <out_dir> [-p <url_prefix>] [-t <theme>]
+    \\    goku build <site_root> -o <out_dir> [-p <url_prefix>] [-t <theme>]
     \\
 ;
 

--- a/src/Site.zig
+++ b/src/Site.zig
@@ -1,3 +1,4 @@
+const assets = @import("assets.zig");
 const BatchAllocator = @import("BatchAllocator.zig");
 const bulma = @import("bulma");
 const htmx = @import("htmx");
@@ -15,6 +16,7 @@ const storage = @import("storage.zig");
 const testing = std.testing;
 const Database = @import("Database.zig");
 const markdown = @import("markdown.zig");
+const theme = @import("theme.zig");
 
 // TODO remove this property
 // Site root is only used for constructing an absolute path to
@@ -25,6 +27,9 @@ url_prefix: ?[]const u8,
 allocator: mem.Allocator,
 db: *Database,
 component_assets: *ComponentAssets,
+selected_theme_name: ?[]const u8,
+themes: theme.Registry,
+asset_manifest: assets.Manifest,
 
 pub const ComponentAssets = struct {
     arena: *heap.ArenaAllocator,
@@ -57,6 +62,18 @@ pub const ComponentAssets = struct {
 };
 
 const Site = @This();
+
+pub const Pagination = struct {
+    collection: []const u8,
+    current_page: u32,
+    per_page: u32,
+    total_items: u32,
+    base_slug: []const u8,
+
+    pub fn totalPages(self: Pagination) u32 {
+        return @max(1, std.math.divCeil(u32, self.total_items, self.per_page) catch 1);
+    }
+};
 
 const HtmlSitemap = struct {
     // HTML HtmlSitemap looks like this:
@@ -127,11 +144,19 @@ pub fn init(
     database: *Database,
     site_root: []const u8,
     url_prefix: ?[]const u8,
+    selected_theme_name: ?[]const u8,
 ) !Site {
     const component_assets = try allocator.create(ComponentAssets);
     errdefer allocator.destroy(component_assets);
     component_assets.* = try .init(allocator, database);
     errdefer component_assets.deinit();
+
+    var themes = theme.Registry.init(allocator);
+    errdefer themes.deinit();
+    try themes.loadSiteThemes(site_root, selected_theme_name);
+
+    var asset_manifest = assets.Manifest.init(allocator);
+    errdefer asset_manifest.deinit();
 
     const site: Site = .{
         .allocator = allocator,
@@ -139,6 +164,9 @@ pub fn init(
         .site_root = site_root,
         .url_prefix = url_prefix,
         .component_assets = component_assets,
+        .selected_theme_name = selected_theme_name,
+        .themes = themes,
+        .asset_manifest = asset_manifest,
     };
 
     try site.validate();
@@ -146,9 +174,15 @@ pub fn init(
     return site;
 }
 
-pub fn deinit(self: Site) void {
+pub fn deinit(self: *Site) void {
     self.component_assets.deinit();
     self.allocator.destroy(self.component_assets);
+    self.themes.deinit();
+    self.asset_manifest.deinit();
+}
+
+fn resolveTheme(self: *const Site, preferred_name: ?[]const u8) ?*const theme.Theme {
+    return self.themes.resolve(preferred_name orelse self.selected_theme_name);
 }
 
 pub fn validate(self: Site) !void {
@@ -217,15 +251,15 @@ pub fn validate(self: Site) !void {
 }
 
 pub fn write(
-    self: Site,
+    self: *Site,
     part: enum { sitemap, assets, pages, component_assets },
     out_dir: fs.Dir,
 ) !void {
     switch (part) {
-        .sitemap => try writeSitemap(self, out_dir),
-        .assets => try writeAssets(out_dir),
-        .pages => try writePages(self, out_dir),
-        .component_assets => try writeComponentAssets(self, out_dir),
+        .sitemap => try writeSitemap(self.*, out_dir),
+        .assets => try writeAssets(self, out_dir),
+        .pages => try writePages(self.*, out_dir),
+        .component_assets => try writeComponentAssets(self.*, out_dir),
     }
 }
 
@@ -240,7 +274,7 @@ fn writeSitemap(self: Site, out_dir: fs.Dir) !void {
     try file_buf.flush();
 }
 
-fn writeAssets(out_dir: fs.Dir) !void {
+fn writeAssets(self: *Site, out_dir: fs.Dir) !void {
     {
         var file = try out_dir.createFile(
             "bulma.css",
@@ -258,6 +292,58 @@ fn writeAssets(out_dir: fs.Dir) !void {
         defer file.close();
         try file.writer().writeAll(htmx.js);
     }
+
+    try self.asset_manifest.processSiteAssets(self.site_root, out_dir);
+    try writeThemeAssets(self.*, out_dir);
+}
+
+fn writeThemeAssets(self: Site, out_dir: fs.Dir) !void {
+    const allocator = self.allocator;
+
+    for (self.themes.map.keys()) |theme_name| {
+        const theme_root = try fs.path.join(allocator, &.{ self.site_root, "themes", theme_name });
+        defer allocator.free(theme_root);
+
+        const walker_subpath = try std.fmt.allocPrint(allocator, "themes/{s}", .{theme_name});
+        defer allocator.free(walker_subpath);
+
+        var walker = @import("source/filesystem.zig").walker(self.site_root, walker_subpath);
+        while (walker.next() catch |err| switch (err) {
+            error.CannotOpenDirectory => break,
+            else => return err,
+        }) |entry| {
+            var source_path_buf: [fs.max_path_bytes]u8 = undefined;
+            const source_abs = try entry.realpath(&source_path_buf);
+            const rel = try fs.path.relative(allocator, theme_root, source_abs);
+            defer allocator.free(rel);
+            if (mem.eql(u8, rel, "theme.yaml")) continue;
+
+            var file = try entry.openFile();
+            defer file.close();
+            const contents = try file.readToEndAlloc(allocator, std.math.maxInt(usize));
+            defer allocator.free(contents);
+
+            const out_rel = try fs.path.join(allocator, &.{ "theme", theme_name, rel });
+            defer allocator.free(out_rel);
+            try writeOutputFile(out_dir, out_rel, contents);
+        }
+    }
+}
+
+fn writeOutputFile(out_dir: fs.Dir, rel_path: []const u8, contents: []const u8) !void {
+    if (fs.path.dirname(rel_path)) |parent| {
+        var dir = try out_dir.makeOpenPath(parent, .{});
+        defer dir.close();
+
+        var file = try dir.createFile(fs.path.basename(rel_path), .{});
+        defer file.close();
+        try file.writeAll(contents);
+        return;
+    }
+
+    var file = try out_dir.createFile(rel_path, .{});
+    defer file.close();
+    try file.writeAll(contents);
 }
 
 fn writePages(self: Site, out_dir: fs.Dir) !void {
@@ -274,18 +360,79 @@ fn writePages(self: Site, out_dir: fs.Dir) !void {
     while (try it.next()) |entry| {
         defer batch_allocator.flush();
 
+        const page_data = try readPageData(batch_allocator.allocator(), entry.filepath);
+        if (page_data.paginate) |per_page| {
+            if (page_data.collection) |collection| {
+                const total_items = try getCollectionCount(self.db, collection);
+                const total_pages = @max(1, std.math.divCeil(u32, total_items, per_page) catch 1);
+
+                var page_number: u32 = 1;
+                while (page_number <= total_pages) : (page_number += 1) {
+                    try _render(
+                        batch_allocator.allocator(),
+                        &self,
+                        entry.filepath,
+                        entry.slug,
+                        .wants_content,
+                        out_dir,
+                        .{
+                            .collection = collection,
+                            .current_page = page_number,
+                            .per_page = per_page,
+                            .total_items = total_items,
+                            .base_slug = entry.slug,
+                        },
+                    );
+                }
+                continue;
+            }
+        }
+
         try _render(
             batch_allocator.allocator(),
-            self.db,
-            self.component_assets,
-            self.url_prefix,
-            self.site_root,
+            &self,
             entry.filepath,
             entry.slug,
             .wants_content,
             out_dir,
+            null,
         );
     }
+}
+
+fn readPageData(allocator: mem.Allocator, filepath: []const u8) !page.Data {
+    var file = try fs.openFileAbsolute(filepath, .{});
+    defer file.close();
+
+    const contents = try file.readToEndAlloc(allocator, std.math.maxInt(u32));
+    const result = page.CodeFence.parse(contents) orelse return error.MalformedPageFile;
+
+    const p: page.Page = .{
+        .markdown = .{
+            .frontmatter = result.within,
+            .content = result.after,
+        },
+    };
+
+    return try p.data(allocator);
+}
+
+fn getCollectionCount(db: *Database, collection: []const u8) !u32 {
+    var stmt = try db.db.prepare(
+        \\SELECT count(*) as count
+        \\FROM pages
+        \\WHERE collection = ?
+    );
+    defer stmt.deinit();
+
+    const row = try stmt.oneAlloc(
+        struct { count: u32 },
+        std.heap.page_allocator,
+        .{},
+        .{ .collection = collection },
+    ) orelse return 0;
+
+    return row.count;
 }
 
 fn writeComponentAssets(self: Site, out_dir: fs.Dir) !void {
@@ -333,14 +480,12 @@ fn writeComponentAssets(self: Site, out_dir: fs.Dir) !void {
 /// to a dedicated styles buffer while rendering.
 fn _render(
     ally: mem.Allocator,
-    db: *Database,
-    component_assets: *ComponentAssets,
-    url_prefix: ?[]const u8,
-    site_root: []const u8,
+    site: *const Site,
     filepath: []const u8,
     slug: []const u8,
     wants: DispatchWants,
     out_dir: fs.Dir,
+    pagination: ?Pagination,
 ) !void {
     switch (wants) {
         .wants_raw => unreachable,
@@ -379,14 +524,19 @@ fn _render(
         var filename_buf = std.ArrayList(u8).init(ally);
         defer filename_buf.deinit();
 
+        const effective_slug = if (pagination) |page_ctx|
+            try paginationSlug(ally, page_ctx)
+        else
+            slug;
+
         // TODO the function accepts slug as an argument but we'll also have
         // the slug after parsing the page metadata out. Is it redundant to
         // accept the slug as a function argument?
-        debug.assert(slug.len > 0);
-        debug.assert(slug[0] == '/');
-        if (slug.len > 1) {
-            debug.assert(!mem.endsWith(u8, slug, "/"));
-            try filename_buf.appendSlice(slug);
+        debug.assert(effective_slug.len > 0);
+        debug.assert(effective_slug[0] == '/');
+        if (effective_slug.len > 1) {
+            debug.assert(!mem.endsWith(u8, effective_slug, "/"));
+            try filename_buf.appendSlice(effective_slug);
         }
         try filename_buf.appendSlice("/index.html");
 
@@ -421,7 +571,7 @@ fn _render(
         if (data.template) |t| {
             const template_path = try fs.path.join(
                 ally,
-                &.{ site_root, "templates", t },
+                &.{ site.site_root, "templates", t },
             );
 
             var template_file = try fs.openFileAbsolute(
@@ -444,9 +594,12 @@ fn _render(
         ally,
         p,
         .{ .bytes = template },
-        db,
-        component_assets,
-        url_prefix,
+        site.db,
+        site.component_assets,
+        site.url_prefix,
+        site.resolveTheme(data.theme),
+        &site.asset_manifest,
+        pagination,
         wants,
         html_buffer.writer(),
     );
@@ -567,6 +720,9 @@ pub fn dispatch(site: *Site, slug: []const u8, writer: anytype, styles_writer: a
                     db,
                     site.component_assets,
                     url_prefix,
+                    site.resolveTheme(data.theme),
+                    &site.asset_manifest,
+                    null,
                     options.wants,
                     html_buffer.writer(),
                 ) catch return DispatchError.RenderError;
@@ -591,6 +747,9 @@ fn renderPage(
     db: *Database,
     component_assets: *ComponentAssets,
     url_prefix: ?[]const u8,
+    selected_theme: ?*const theme.Theme,
+    asset_manifest: *const assets.Manifest,
+    pagination: ?Pagination,
     wants: DispatchWants,
     writer: anytype,
 ) !void {
@@ -619,6 +778,9 @@ fn renderPage(
                 .data = meta,
                 .site_root = url_prefix orelse "",
                 .component_assets = component_assets,
+                .theme = selected_theme,
+                .asset_manifest = asset_manifest,
+                .pagination = pagination,
             },
             buf.writer(),
         );
@@ -656,9 +818,23 @@ fn renderPage(
             .content = content_buf.items,
             .site_root = url_prefix orelse "",
             .component_assets = component_assets,
+            .theme = selected_theme,
+            .asset_manifest = asset_manifest,
+            .pagination = pagination,
         },
         writer,
     );
+}
+
+fn paginationSlug(allocator: mem.Allocator, page_ctx: Pagination) ![]const u8 {
+    if (page_ctx.current_page <= 1) {
+        return page_ctx.base_slug;
+    }
+
+    return if (mem.eql(u8, page_ctx.base_slug, "/"))
+        try std.fmt.allocPrint(allocator, "/page/{d}", .{page_ctx.current_page})
+    else
+        try std.fmt.allocPrint(allocator, "{s}/page/{d}", .{ page_ctx.base_slug, page_ctx.current_page });
 }
 
 const @"test" = struct {
@@ -693,21 +869,24 @@ const @"test" = struct {
         var buf = std.ArrayList(u8).init(testing.allocator);
         defer buf.deinit();
 
-        var styles_buf = std.ArrayList(u8).init(testing.allocator);
-        defer styles_buf.deinit();
-        var scripts_buf = std.ArrayList(u8).init(testing.allocator);
-        defer scripts_buf.deinit();
+        var component_assets = try ComponentAssets.init(testing.allocator, &db);
+        defer component_assets.deinit();
+
+        var asset_manifest = assets.Manifest.init(testing.allocator);
+        defer asset_manifest.deinit();
 
         try renderPage(
             testing.allocator,
             page_to_render,
             .{ .bytes = template },
             &db,
+            &component_assets,
+            null,
+            null,
+            &asset_manifest,
             null,
             .wants_content,
             buf.writer(),
-            styles_buf.writer(),
-            scripts_buf.writer(),
         );
 
         try testing.expectEqualStrings(expected, buf.items);

--- a/src/assets.zig
+++ b/src/assets.zig
@@ -1,0 +1,98 @@
+const fs = std.fs;
+const heap = std.heap;
+const mem = std.mem;
+const std = @import("std");
+const filesystem = @import("source/filesystem.zig");
+const testing = std.testing;
+
+pub const Manifest = struct {
+    arena: heap.ArenaAllocator,
+    map: std.StringArrayHashMapUnmanaged([]const u8),
+
+    pub fn init(allocator: mem.Allocator) Manifest {
+        return .{
+            .arena = heap.ArenaAllocator.init(allocator),
+            .map = .empty,
+        };
+    }
+
+    pub fn deinit(self: *Manifest) void {
+        self.map.deinit(self.arena.allocator());
+        self.arena.deinit();
+        self.* = undefined;
+    }
+
+    pub fn get(self: *const Manifest, path: []const u8) ?[]const u8 {
+        return self.map.get(path);
+    }
+
+    pub fn processSiteAssets(self: *Manifest, site_root: []const u8, out_dir: fs.Dir) !void {
+        var root_dir = try fs.openDirAbsolute(site_root, .{});
+        defer root_dir.close();
+
+        _ = root_dir.access("assets", .{}) catch |err| switch (err) {
+            error.FileNotFound => return,
+            else => return err,
+        };
+
+        const allocator = self.arena.allocator();
+        const assets_root = try fs.path.join(allocator, &.{ site_root, "assets" });
+
+        var walker = filesystem.walker(site_root, "assets");
+        while (try walker.next()) |entry| {
+            const source_abs = try entry.realpath(try allocator.alloc(u8, fs.max_path_bytes));
+            const rel = try fs.path.relative(allocator, assets_root, source_abs);
+            const contents = blk: {
+                var file = try entry.openFile();
+                defer file.close();
+                break :blk try file.readToEndAlloc(allocator, std.math.maxInt(usize));
+            };
+
+            const hashed_rel = try hashedRelativePath(allocator, rel, contents);
+            try writeAsset(out_dir, hashed_rel, contents);
+            try self.map.put(allocator, try allocator.dupe(u8, rel), hashed_rel);
+        }
+    }
+
+    fn writeAsset(out_dir: fs.Dir, relative_path: []const u8, contents: []const u8) !void {
+        if (fs.path.dirname(relative_path)) |parent| {
+            var dir = try out_dir.makeOpenPath(parent, .{});
+            defer dir.close();
+
+            var file = try dir.createFile(fs.path.basename(relative_path), .{});
+            defer file.close();
+            try file.writeAll(contents);
+            return;
+        }
+
+        var file = try out_dir.createFile(relative_path, .{});
+        defer file.close();
+        try file.writeAll(contents);
+    }
+};
+
+pub fn hashedRelativePath(allocator: mem.Allocator, rel: []const u8, contents: []const u8) ![]const u8 {
+    var digest: [std.crypto.hash.Md5.digest_length]u8 = undefined;
+    std.crypto.hash.Md5.hash(contents, &digest, .{});
+
+    var hash_buf: [12]u8 = undefined;
+    _ = std.fmt.bufPrint(&hash_buf, "{s}", .{std.fmt.fmtSliceHexLower(digest[0..6])}) catch unreachable;
+
+    const dirname = fs.path.dirname(rel);
+    const basename = fs.path.basename(rel);
+    const ext = fs.path.extension(basename);
+    const stem = basename[0 .. basename.len - ext.len];
+
+    return if (dirname) |parent|
+        try fs.path.join(allocator, &.{ "assets", parent, try std.fmt.allocPrint(allocator, "{s}-{s}{s}", .{ stem, hash_buf[0 .. digest[0..6].len * 2], ext }) })
+    else
+        try fs.path.join(allocator, &.{ "assets", try std.fmt.allocPrint(allocator, "{s}-{s}{s}", .{ stem, hash_buf[0 .. digest[0..6].len * 2], ext }) });
+}
+
+test hashedRelativePath {
+    const value = try hashedRelativePath(testing.allocator, "images/logo.png", "hello");
+    defer testing.allocator.free(value);
+
+    try testing.expect(mem.startsWith(u8, value, "assets/images/logo-"));
+    try testing.expect(mem.endsWith(u8, value, ".png"));
+}

--- a/src/goku.zig
+++ b/src/goku.zig
@@ -32,7 +32,7 @@ pub fn build(unlimited_allocator: mem.Allocator, args: cli.Command.Build) !void 
 
     try indexSite(unlimited_allocator, site_root, &db);
 
-    var site: Site = try .init(unlimited_allocator, &db, site_root, args.url_prefix);
+    var site: Site = try .init(unlimited_allocator, &db, site_root, args.url_prefix, args.theme);
     defer site.deinit();
 
     var out_dir = if (fs.path.isAbsolute(args.out_dir))
@@ -69,7 +69,7 @@ pub fn preview(unlimited_allocator: mem.Allocator, args: cli.Command.Preview) !v
 
     try indexSite(unlimited_allocator, site_root, &db);
 
-    var site: Site = try .init(unlimited_allocator, &db, site_root, args.url_prefix);
+    var site: Site = try .init(unlimited_allocator, &db, site_root, args.url_prefix, args.theme);
     defer site.deinit();
 
     var out_dir = try fs.openDirAbsolute(args.out_dir, .{});
@@ -130,7 +130,7 @@ const PreviewServer = struct {
         defer styles_buf.deinit();
 
         var scripts_buf = std.ArrayList(u8).init(req.arena);
-        defer styles_buf.deinit();
+        defer scripts_buf.deinit();
 
         context.site.dispatch(req.url.path, res.writer(), styles_buf.writer(), scripts_buf.writer(), .{ .wants = config }) catch |err| {
             switch (err) {
@@ -147,22 +147,48 @@ const PreviewServer = struct {
                     var dir = try fs.openDirAbsolute(context.out_dir, .{});
                     defer dir.close();
 
-                    var file = dir.openFile(sub_path, .{}) catch |err2| {
-                        switch (err2) {
-                            error.FileNotFound => {
-                                res.status = 404;
-                                res.body = "Not foond";
-                                return;
-                            },
+                    const resolved_path = resolved_path: {
+                        const stat = dir.statFile(sub_path) catch |stat_err| switch (stat_err) {
+                            error.FileNotFound => null,
                             else => {
-                                std.log.err("Encountered error when dispatching request: {any}", .{err2});
+                                std.log.err("Encountered error when dispatching request: {any}", .{stat_err});
                                 res.status = 500;
                                 res.body = "Uh oh!";
                                 return;
                             },
+                        };
+
+                        if (stat) |sub_stat| {
+                            switch (sub_stat.kind) {
+                                .file => break :resolved_path sub_path,
+                                .directory => break :resolved_path try fs.path.join(req.arena, &.{ sub_path, "index.html" }),
+                                else => {
+                                    res.status = 404;
+                                    res.body = "Not foond";
+                                    return;
+                                },
+                            }
                         }
+
+                        break :resolved_path try fs.path.join(req.arena, &.{ sub_path, "index.html" });
+                    };
+
+                    var file = dir.openFile(resolved_path, .{}) catch |open_err| switch (open_err) {
+                        error.FileNotFound => {
+                            res.status = 404;
+                            res.body = "Not foond";
+                            return;
+                        },
+                        else => {
+                            std.log.err("Encountered error when dispatching request: {any}", .{open_err});
+                            res.status = 500;
+                            res.body = "Uh oh!";
+                            return;
+                        },
                     };
                     defer file.close();
+
+                    setStaticContentType(res, resolved_path);
 
                     var buf: [1024]u8 = undefined;
                     const reader = file.reader();
@@ -174,7 +200,7 @@ const PreviewServer = struct {
                     }
 
                     res.header("Cache-Control", "max-age=10");
-                    log.info("Done serving {s}", .{sub_path});
+                    log.info("Done serving {s}", .{resolved_path});
                 },
             }
         };
@@ -267,6 +293,11 @@ const PreviewServer = struct {
     fn redirect(status_code: u16, url: []const u8, res: *httpz.Response) void {
         res.status = status_code;
         res.header("Location", url);
+    }
+
+    fn setStaticContentType(res: *httpz.Response, path: []const u8) void {
+        const ext = fs.path.extension(path);
+        res.content_type = httpz.ContentType.forExtension(ext);
     }
 };
 

--- a/src/markdown.zig
+++ b/src/markdown.zig
@@ -316,9 +316,7 @@ fn ParserType(comptime Writer: type) type {
                 c.MD_SPAN_CODE => writer.writeAll("</code>") catch return -1,
                 c.MD_SPAN_DEL => {},
                 c.MD_SPAN_EM => {},
-                c.MD_SPAN_IMG => {
-                    std.log.info("why leave an image...", .{});
-                },
+                c.MD_SPAN_IMG => {},
                 c.MD_SPAN_STRONG => writer.writeAll("</strong>") catch return -1,
                 c.MD_SPAN_U => {},
 

--- a/src/mustache.zig
+++ b/src/mustache.zig
@@ -1,3 +1,4 @@
+const assets = @import("assets.zig");
 const c = @import("c");
 const debug = std.debug;
 const fmt = std.fmt;
@@ -15,6 +16,8 @@ const std = @import("std");
 const storage = @import("storage.zig");
 const testing = std.testing;
 const ComponentAssets = @import("Site.zig").ComponentAssets;
+const Pagination = @import("Site.zig").Pagination;
+const Theme = @import("theme.zig").Theme;
 
 pub fn renderStream(allocator: mem.Allocator, template: []const u8, context: anytype, writer: anytype) !void {
     var arena = heap.ArenaAllocator.init(allocator);
@@ -104,7 +107,12 @@ fn GetHandleType(comptime UserContext: type) type {
                             const value = @field(get_handle.user_context.data, f.name);
 
                             if (value) |v| {
-                                return try arena.dupeZ(u8, v);
+                                switch (@typeInfo(@TypeOf(v))) {
+                                    .pointer => return try arena.dupeZ(u8, v),
+                                    .int, .comptime_int => return try fmt.allocPrint(arena, "{d}", .{v}),
+                                    .bool => return if (v) "true" else "false",
+                                    else => return error.UnsupportedDataFieldType,
+                                }
                             }
 
                             return "";
@@ -129,12 +137,15 @@ fn GetHandleType(comptime UserContext: type) type {
             var list_buf = std.ArrayList(u8).init(arena);
             defer list_buf.deinit();
 
+            const pagination = getPagination(get_handle, collection);
             const get_pages = .{
                 .stmt =
                 \\SELECT slug, date, title
                 \\FROM pages
                 \\WHERE collection = ?
+                \\AND slug != ?
                 \\ORDER BY date DESC, title ASC
+                \\LIMIT ? OFFSET ?
                 ,
                 .type = struct {
                     slug: []const u8,
@@ -146,9 +157,17 @@ fn GetHandleType(comptime UserContext: type) type {
             var get_stmt = try get_handle.user_context.db.db.prepare(get_pages.stmt);
             defer get_stmt.deinit();
 
+            const limit: u32 = if (pagination) |page_ctx| page_ctx.per_page else std.math.maxInt(u32);
+            const offset: u32 = if (pagination) |page_ctx| (page_ctx.current_page - 1) * page_ctx.per_page else 0;
+
             var it = try get_stmt.iterator(
                 get_pages.type,
-                .{ .collection = collection },
+                .{
+                    .collection = collection,
+                    .slug = get_handle.user_context.data.slug,
+                    .limit = limit,
+                    .offset = offset,
+                },
             );
 
             try list_buf.appendSlice("<ul>");
@@ -179,6 +198,19 @@ fn GetHandleType(comptime UserContext: type) type {
             }
 
             return "";
+        }
+
+        fn getPagination(get_handle: *GetHandle, collection: []const u8) ?Pagination {
+            if (!@hasField(UserContext, "pagination")) return null;
+
+            const pagination = @field(get_handle.user_context, "pagination");
+            if (pagination) |page_ctx| {
+                if (mem.eql(u8, page_ctx.collection, collection)) {
+                    return page_ctx;
+                }
+            }
+
+            return null;
         }
 
         fn getCollectionsLatest(get_handle: *GetHandle, arena: mem.Allocator, collection: []const u8) ![]const u8 {
@@ -543,34 +575,166 @@ fn MustacheWriterType(comptime UserContext: type) type {
                 }
             };
 
+            const AssetGetter = struct {
+                pub fn getAssetPath(mw: *MustacheWriter, k: []const u8) !?[]const u8 {
+                    if (!mem.startsWith(u8, k, "asset ")) return null;
+                    if (!@hasField(UserContext, "asset_manifest")) return error.MissingAsset;
+
+                    const raw_path = mem.trim(u8, k["asset ".len..], "\"'");
+                    const manifest: *const assets.Manifest = @field(mw.context.user_context, "asset_manifest");
+                    const resolved = manifest.get(raw_path) orelse return error.MissingAsset;
+                    return try fmt.allocPrint(mw.arena, "{s}/{s}", .{ mw.context.user_context.site_root, resolved });
+                }
+            };
+
             const ThemeGetter = struct {
-                pub fn getThemeHead(mw: *MustacheWriter, k: []const u8) !?[]const u8 {
-                    return if (mem.eql(u8, k, "theme.head"))
-                        try fmt.allocPrint(
-                            mw.arena,
-                            \\<link rel="stylesheet" type="text/css" href="{[site_root]s}/bulma.css" />
+                fn themeAssetUrl(mw: *MustacheWriter, selected_theme: *const Theme, asset_path: []const u8) ![]const u8 {
+                    if (mem.startsWith(u8, asset_path, "http://") or mem.startsWith(u8, asset_path, "https://")) {
+                        return try mw.arena.dupe(u8, asset_path);
+                    }
+
+                    if (asset_path.len > 0 and asset_path[0] == '/') {
+                        return try fmt.allocPrint(mw.arena, "{s}{s}", .{ mw.context.user_context.site_root, asset_path });
+                    }
+
+                    if (mem.eql(u8, asset_path, "bulma.css") or mem.eql(u8, asset_path, "htmx.js")) {
+                        return try fmt.allocPrint(mw.arena, "{s}/{s}", .{ mw.context.user_context.site_root, asset_path });
+                    }
+
+                    return try fmt.allocPrint(mw.arena, "{s}/theme/{s}/{s}", .{ mw.context.user_context.site_root, selected_theme.name, asset_path });
+                }
+
+                fn selectedTheme(mw: *MustacheWriter) ?*const Theme {
+                    if (!@hasField(UserContext, "theme")) return null;
+                    return @field(mw.context.user_context, "theme");
+                }
+
+                fn renderStyles(mw: *MustacheWriter, selected_theme: *const Theme) ![]const u8 {
+                    var buf = std.ArrayList(u8).init(mw.arena);
+                    for (selected_theme.styles) |style| {
+                        try buf.writer().print(
+                            "<link rel=\"stylesheet\" type=\"text/css\" href=\"{s}\" />"
                         ,
-                            .{ .site_root = mw.context.user_context.site_root },
-                        )
-                    else
-                        null;
+                            .{try themeAssetUrl(mw, selected_theme, style)},
+                        );
+                    }
+                    return if (buf.items.len == 0) "" else try buf.toOwnedSlice();
+                }
+
+                fn renderScripts(mw: *MustacheWriter, selected_theme: *const Theme) ![]const u8 {
+                    var buf = std.ArrayList(u8).init(mw.arena);
+                    for (selected_theme.scripts) |script| {
+                        try buf.writer().print(
+                            "<script src=\"{s}\"></script>"
+                        ,
+                            .{try themeAssetUrl(mw, selected_theme, script)},
+                        );
+                    }
+                    return if (buf.items.len == 0) "" else try buf.toOwnedSlice();
+                }
+
+                pub fn getThemeHead(mw: *MustacheWriter, k: []const u8) !?[]const u8 {
+                    if (!mem.eql(u8, k, "theme.head")) return null;
+
+                    if (selectedTheme(mw)) |selected_theme| {
+                        return try renderStyles(mw, selected_theme);
+                    }
+
+                    return try fmt.allocPrint(
+                        mw.arena,
+                        \\<link rel="stylesheet" type="text/css" href="{[site_root]s}/bulma.css" />
+                    ,
+                        .{ .site_root = mw.context.user_context.site_root },
+                    );
                 }
 
                 pub fn getThemeBody(mw: *MustacheWriter, k: []const u8) !?[]const u8 {
-                    return if (mem.eql(u8, k, "theme.body"))
-                        // theme.body can be used by themes to inject e.g. scripts.
-                        // It's currently empty, but content authors are still recommended
-                        // to include it in their templates to allow a more seamless upgrade
-                        // once themes do make use of it.
+                    if (!mem.eql(u8, k, "theme.body")) return null;
 
-                        return try fmt.allocPrint(
-                            mw.arena,
-                            \\<script src="{[site_root]s}/htmx.js"></script>
-                        ,
-                            .{ .site_root = mw.context.user_context.site_root },
-                        )
+                    if (selectedTheme(mw)) |selected_theme| {
+                        return try renderScripts(mw, selected_theme);
+                    }
+
+                    return try fmt.allocPrint(
+                        mw.arena,
+                        \\<script src="{[site_root]s}/htmx.js"></script>
+                    ,
+                        .{ .site_root = mw.context.user_context.site_root },
+                    );
+                }
+
+                pub fn getThemeValue(mw: *MustacheWriter, k: []const u8) !?[]const u8 {
+                    if (!mem.eql(u8, k, "theme.name")) return null;
+
+                    if (selectedTheme(mw)) |selected_theme| {
+                        return try mw.arena.dupeZ(u8, selected_theme.name);
+                    }
+
+                    return "default";
+                }
+            };
+
+            const PaginationGetter = struct {
+                fn currentPagination(mw: *MustacheWriter) ?Pagination {
+                    if (!@hasField(UserContext, "pagination")) return null;
+                    return @field(mw.context.user_context, "pagination");
+                }
+
+                fn pageUrl(mw: *MustacheWriter, base_slug: []const u8, page_number: u32) ![]const u8 {
+                    if (page_number <= 1) {
+                        return try fmt.allocPrint(mw.arena, "{s}{s}", .{ mw.context.user_context.site_root, base_slug });
+                    }
+
+                    return if (mem.eql(u8, base_slug, "/"))
+                        try fmt.allocPrint(mw.arena, "{s}/page/{d}", .{ mw.context.user_context.site_root, page_number })
                     else
-                        null;
+                        try fmt.allocPrint(mw.arena, "{s}{s}/page/{d}", .{ mw.context.user_context.site_root, base_slug, page_number });
+                }
+
+                pub fn getCurrent(mw: *MustacheWriter, k: []const u8) !?[]const u8 {
+                    if (!mem.eql(u8, k, "pagination.current")) return null;
+                    const pagination = currentPagination(mw) orelse return "";
+                    return try fmt.allocPrint(mw.arena, "{d}", .{pagination.current_page});
+                }
+
+                pub fn getTotal(mw: *MustacheWriter, k: []const u8) !?[]const u8 {
+                    if (!mem.eql(u8, k, "pagination.total")) return null;
+                    const pagination = currentPagination(mw) orelse return "";
+                    return try fmt.allocPrint(mw.arena, "{d}", .{pagination.totalPages()});
+                }
+
+                pub fn getPrevUrl(mw: *MustacheWriter, k: []const u8) !?[]const u8 {
+                    if (!mem.eql(u8, k, "pagination.prev_url")) return null;
+                    const pagination = currentPagination(mw) orelse return "";
+                    if (pagination.current_page <= 1) return "";
+                    return try pageUrl(mw, pagination.base_slug, pagination.current_page - 1);
+                }
+
+                pub fn getNextUrl(mw: *MustacheWriter, k: []const u8) !?[]const u8 {
+                    if (!mem.eql(u8, k, "pagination.next_url")) return null;
+                    const pagination = currentPagination(mw) orelse return "";
+                    if (pagination.current_page >= pagination.totalPages()) return "";
+                    return try pageUrl(mw, pagination.base_slug, pagination.current_page + 1);
+                }
+
+                pub fn getNav(mw: *MustacheWriter, k: []const u8) !?[]const u8 {
+                    if (!mem.eql(u8, k, "pagination.nav")) return null;
+                    const pagination = currentPagination(mw) orelse return "";
+                    if (pagination.totalPages() <= 1) return "";
+
+                    var buf = std.ArrayList(u8).init(mw.arena);
+                    try buf.appendSlice("<nav class=\"pagination\">");
+
+                    if (pagination.current_page > 1) {
+                        try buf.writer().print("<a href=\"{s}\">Previous</a>", .{try pageUrl(mw, pagination.base_slug, pagination.current_page - 1)});
+                    }
+                    try buf.writer().print("<span>Page {d} of {d}</span>", .{ pagination.current_page, pagination.totalPages() });
+                    if (pagination.current_page < pagination.totalPages()) {
+                        try buf.writer().print("<a href=\"{s}\">Next</a>", .{try pageUrl(mw, pagination.base_slug, pagination.current_page + 1)});
+                    }
+
+                    try buf.appendSlice("</nav>");
+                    return try buf.toOwnedSlice();
                 }
             };
 
@@ -582,11 +746,18 @@ fn MustacheWriterType(comptime UserContext: type) type {
                     .{ .simple = LucideGetter.getIcon },
                     .{ .ctx = CollectionGetter.getList },
                     .{ .ctx = CollectionGetter.getLatest },
+                    .{ .ctx = PaginationGetter.getCurrent },
+                    .{ .ctx = PaginationGetter.getTotal },
+                    .{ .ctx = PaginationGetter.getPrevUrl },
+                    .{ .ctx = PaginationGetter.getNextUrl },
+                    .{ .ctx = PaginationGetter.getNav },
                     .{ .ctx = ComponentGetter.getStyleRef },
                     .{ .ctx = ComponentGetter.getScriptRef },
                     .{ .ctx = ComponentGetter.getComponent },
+                    .{ .ctx = AssetGetter.getAssetPath },
                     .{ .ctx = ThemeGetter.getThemeHead },
                     .{ .ctx = ThemeGetter.getThemeBody },
+                    .{ .ctx = ThemeGetter.getThemeValue },
                 };
 
                 for (getters) |getter| {

--- a/src/page/Data.zig
+++ b/src/page/Data.zig
@@ -15,6 +15,8 @@ title: ?[]const u8 = null,
 date: ?[]const u8 = null,
 template: ?[]const u8 = null,
 description: ?[]const u8 = null,
+theme: ?[]const u8 = null,
+paginate: ?u32 = null,
 allow_html: bool = false,
 options_toc: bool = false,
 
@@ -87,6 +89,8 @@ pub fn fromYamlString(allocator: mem.Allocator, data: []const u8, diag: ?*Diagno
         description,
         template,
         allow_html,
+        theme,
+        paginate,
         tags,
     } = .key;
     var slug: ?[]const u8 = null;
@@ -106,6 +110,11 @@ pub fn fromYamlString(allocator: mem.Allocator, data: []const u8, diag: ?*Diagno
 
     var date: ?[]const u8 = null;
     errdefer if (date) |f| allocator.free(f);
+
+    var theme: ?[]const u8 = null;
+    errdefer if (theme) |f| allocator.free(f);
+
+    var paginate: ?u32 = null;
 
     var allow_html: bool = false;
 
@@ -149,6 +158,10 @@ pub fn fromYamlString(allocator: mem.Allocator, data: []const u8, diag: ?*Diagno
                             next_scalar_expected = .template;
                         } else if (mem.eql(u8, value, "allow_html")) {
                             next_scalar_expected = .allow_html;
+                        } else if (mem.eql(u8, value, "theme")) {
+                            next_scalar_expected = .theme;
+                        } else if (mem.eql(u8, value, "paginate")) {
+                            next_scalar_expected = .paginate;
                         } else {
                             next_scalar_expected = .discard;
                         }
@@ -190,6 +203,14 @@ pub fn fromYamlString(allocator: mem.Allocator, data: []const u8, diag: ?*Diagno
                         description = try allocator.dupe(u8, value);
                         next_scalar_expected = .key;
                     },
+                    .theme => {
+                        theme = try allocator.dupe(u8, value);
+                        next_scalar_expected = .key;
+                    },
+                    .paginate => {
+                        paginate = try fmt.parseInt(u32, value, 10);
+                        next_scalar_expected = .key;
+                    },
                     .discard => {
                         next_scalar_expected = .key;
                     },
@@ -221,6 +242,8 @@ pub fn fromYamlString(allocator: mem.Allocator, data: []const u8, diag: ?*Diagno
         .allow_html = allow_html,
         .date = date,
         .description = description,
+        .theme = theme,
+        .paginate = paginate,
     };
 }
 
@@ -243,6 +266,9 @@ pub fn deinit(self: Data, allocator: mem.Allocator) void {
 
     if (self.description) |description| {
         allocator.free(description);
+    }
+    if (self.theme) |theme| {
+        allocator.free(theme);
     }
 }
 

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,4 +1,5 @@
 pub const BatchAllocator = @import("BatchAllocator.zig");
+pub const assets = @import("assets.zig");
 pub const c = @import("c");
 pub const Database = @import("Database.zig");
 pub const Goku = @import("Goku.zig");
@@ -9,6 +10,7 @@ pub const page = @import("page.zig");
 pub const Site = @import("Site.zig");
 pub const @"source/filesystem" = @import("source/filesystem.zig");
 pub const storage = @import("storage.zig");
+pub const theme = @import("theme.zig");
 pub const httpz = @import("httpz");
 //pub const vhtml = @import("vhtml");
 //pub const bulma = @import("bulma");

--- a/src/scaffold.zig
+++ b/src/scaffold.zig
@@ -2,6 +2,8 @@ const fs = @import("std").fs;
 
 pub fn check(dir: *fs.Dir) !void {
     if (try exists(dir, ".gitignore") or
+        try exists(dir, "assets") or
+        try exists(dir, "themes") or
         try exists(dir, "pages") or
         try exists(dir, "templates") or
         try exists(dir, "components") or
@@ -50,6 +52,18 @@ pub fn write(dir: *fs.Dir) !void {
             .data = @embedFile("scaffold/site_template/components/button.js"),
         });
     }
+
+    {
+        var themes_dir = try dir.makeOpenPath("themes/default", .{});
+        defer themes_dir.close();
+
+        try themes_dir.writeFile(.{
+            .sub_path = "theme.yaml",
+            .data = @embedFile("scaffold/site_template/themes/default/theme.yaml"),
+        });
+    }
+
+    try dir.makeDir("assets");
 
     try dir.makeDir("build");
 }

--- a/src/scaffold/site_template/themes/default/theme.yaml
+++ b/src/scaffold/site_template/themes/default/theme.yaml
@@ -1,0 +1,5 @@
+name: default
+styles:
+  - bulma.css
+scripts:
+  - htmx.js

--- a/src/theme.zig
+++ b/src/theme.zig
@@ -1,0 +1,204 @@
+const c = @import("c");
+const fs = std.fs;
+const heap = std.heap;
+const mem = std.mem;
+const std = @import("std");
+const testing = std.testing;
+
+pub const Theme = struct {
+    name: []const u8,
+    styles: [][]const u8,
+    scripts: [][]const u8,
+};
+
+pub const Registry = struct {
+    arena: heap.ArenaAllocator,
+    map: std.StringArrayHashMapUnmanaged(Theme),
+    default_name: ?[]const u8,
+
+    pub fn init(allocator: mem.Allocator) Registry {
+        return .{
+            .arena = heap.ArenaAllocator.init(allocator),
+            .map = .empty,
+            .default_name = null,
+        };
+    }
+
+    pub fn deinit(self: *Registry) void {
+        self.map.deinit(self.arena.allocator());
+        self.arena.deinit();
+        self.* = undefined;
+    }
+
+    pub fn loadSiteThemes(self: *Registry, site_root: []const u8, preferred_name: ?[]const u8) !void {
+        var root_dir = try fs.openDirAbsolute(site_root, .{ .iterate = true });
+        defer root_dir.close();
+
+        var themes_dir = root_dir.openDir("themes", .{ .iterate = true }) catch |err| switch (err) {
+            error.FileNotFound => return,
+            else => return err,
+        };
+        defer themes_dir.close();
+
+        var it = themes_dir.iterate();
+        while (try it.next()) |entry| {
+            if (entry.kind != .directory) continue;
+
+            const theme_name = try self.arena.allocator().dupe(u8, entry.name);
+            const theme = try loadThemeDirectory(self.arena.allocator(), themes_dir, entry.name, theme_name);
+            try self.map.put(self.arena.allocator(), theme.name, theme);
+
+            if (self.default_name == null and mem.eql(u8, theme.name, "default")) {
+                self.default_name = theme.name;
+            }
+        }
+
+        if (preferred_name) |name| {
+            if (self.map.contains(name)) {
+                self.default_name = self.map.getKey(name).?;
+            }
+        }
+    }
+
+    pub fn resolve(self: *const Registry, preferred_name: ?[]const u8) ?*const Theme {
+        if (preferred_name) |name| {
+            if (self.map.getPtr(name)) |theme| return theme;
+        }
+
+        if (self.default_name) |name| {
+            if (self.map.getPtr(name)) |theme| return theme;
+        }
+
+        return null;
+    }
+
+    fn loadThemeDirectory(allocator: mem.Allocator, themes_dir: fs.Dir, dir_name: []const u8, fallback_name: []const u8) !Theme {
+        var dir = try themes_dir.openDir(dir_name, .{});
+        defer dir.close();
+
+        const theme_file = dir.readFileAlloc(allocator, "theme.yaml", std.math.maxInt(u32)) catch |err| switch (err) {
+            error.FileNotFound => {
+                return .{
+                    .name = fallback_name,
+                    .styles = &.{},
+                    .scripts = &.{},
+                };
+            },
+            else => return err,
+        };
+
+        return try fromYamlString(allocator, theme_file, fallback_name);
+    }
+};
+
+pub fn fromYamlString(allocator: mem.Allocator, data: []const u8, fallback_name: []const u8) !Theme {
+    var parser: c.yaml_parser_t = undefined;
+    const parser_ptr: [*c]c.yaml_parser_t = &parser;
+
+    if (c.yaml_parser_initialize(parser_ptr) == 0) {
+        return error.YamlParserInit;
+    }
+    defer c.yaml_parser_delete(parser_ptr);
+
+    c.yaml_parser_set_input_string(parser_ptr, @ptrCast(data), data.len);
+
+    var ev: c.yaml_event_t = undefined;
+    const ev_ptr: [*c]c.yaml_event_t = &ev;
+
+    var name: ?[]const u8 = null;
+    var styles = std.ArrayList([]const u8).init(allocator);
+    errdefer styles.deinit();
+    var scripts = std.ArrayList([]const u8).init(allocator);
+    errdefer scripts.deinit();
+
+    var done = false;
+    var key_state: enum {
+        key,
+        name,
+        styles,
+        scripts,
+        discard,
+    } = .key;
+
+    while (!done) {
+        if (c.yaml_parser_parse(parser_ptr, ev_ptr) == 0) {
+            return error.Parse;
+        }
+
+        switch (ev.type) {
+            c.YAML_SCALAR_EVENT => {
+                const scalar = ev.data.scalar;
+                const value = scalar.value[0..scalar.length];
+
+                switch (key_state) {
+                    .key => {
+                        if (mem.eql(u8, value, "name")) {
+                            key_state = .name;
+                        } else if (mem.eql(u8, value, "styles")) {
+                            key_state = .styles;
+                        } else if (mem.eql(u8, value, "scripts")) {
+                            key_state = .scripts;
+                        } else {
+                            key_state = .discard;
+                        }
+                    },
+                    .name => {
+                        name = try allocator.dupe(u8, value);
+                        key_state = .key;
+                    },
+                    .styles => {
+                        try styles.append(try allocator.dupe(u8, value));
+                    },
+                    .scripts => {
+                        try scripts.append(try allocator.dupe(u8, value));
+                    },
+                    .discard => {
+                        key_state = .key;
+                    },
+                }
+            },
+            c.YAML_SEQUENCE_END_EVENT => {
+                if (key_state == .styles or key_state == .scripts) {
+                    key_state = .key;
+                }
+            },
+            c.YAML_MAPPING_END_EVENT => {
+                key_state = .key;
+            },
+            else => {},
+        }
+
+        done = (ev.type == c.YAML_STREAM_END_EVENT);
+        c.yaml_event_delete(ev_ptr);
+    }
+
+    return .{
+        .name = name orelse fallback_name,
+        .styles = try styles.toOwnedSlice(),
+        .scripts = try scripts.toOwnedSlice(),
+    };
+}
+
+test fromYamlString {
+    const yaml =
+        \\name: default
+        \\styles:
+        \\  - bulma.css
+        \\  - assets/site.css
+        \\scripts:
+        \\  - htmx.js
+    ;
+
+    const theme = try fromYamlString(testing.allocator, yaml, "fallback");
+    defer {
+        testing.allocator.free(theme.name);
+        for (theme.styles) |style| testing.allocator.free(style);
+        testing.allocator.free(theme.styles);
+        for (theme.scripts) |script| testing.allocator.free(script);
+        testing.allocator.free(theme.scripts);
+    }
+
+    try testing.expectEqualStrings("default", theme.name);
+    try testing.expectEqual(@as(usize, 2), theme.styles.len);
+    try testing.expectEqual(@as(usize, 1), theme.scripts.len);
+}


### PR DESCRIPTION
This pull request introduces site theme support and pagination functionality, as well as updates to asset handling and CLI options. The changes enable users to specify a theme for their site via the CLI, manage and resolve themes within the site, copy theme assets during the build process, and support paginated collections in page rendering. Additionally, the dependency on `http.zig` has been updated.

**Theme Support and Asset Handling:**

- Added a `theme` option to the CLI for both `build` and `preview` commands, allowing users to specify a site theme. The help text and argument parsing logic have been updated accordingly. (`src/Cli.zig`) [[1]](diffhunk://#diff-3183855e282910154b0972ec54d9348bebf4c2aac6ce43349c8ba18d19692662R30) [[2]](diffhunk://#diff-3183855e282910154b0972ec54d9348bebf4c2aac6ce43349c8ba18d19692662R45) [[3]](diffhunk://#diff-3183855e282910154b0972ec54d9348bebf4c2aac6ce43349c8ba18d19692662R69) [[4]](diffhunk://#diff-3183855e282910154b0972ec54d9348bebf4c2aac6ce43349c8ba18d19692662R78-R80) [[5]](diffhunk://#diff-3183855e282910154b0972ec54d9348bebf4c2aac6ce43349c8ba18d19692662R96-R104) [[6]](diffhunk://#diff-3183855e282910154b0972ec54d9348bebf4c2aac6ce43349c8ba18d19692662R113-R115) [[7]](diffhunk://#diff-3183855e282910154b0972ec54d9348bebf4c2aac6ce43349c8ba18d19692662R130) [[8]](diffhunk://#diff-3183855e282910154b0972ec54d9348bebf4c2aac6ce43349c8ba18d19692662L157-R170)
- Integrated theme management into the `Site` struct, including loading, resolving, and deinitializing themes, as well as copying theme assets into the build output. (`src/Site.zig`) [[1]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R1) [[2]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R19) [[3]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R30-R32) [[4]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R147-R185) [[5]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935L243-R277) [[6]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R295-R346)
- Updated the asset pipeline to process both generic site assets and theme-specific assets, ensuring all necessary files are included in the build output. (`src/Site.zig`) [[1]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935L243-R277) [[2]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R295-R346)

**Pagination Functionality:**

- Introduced a `Pagination` struct and logic to support paginated collections when rendering pages. This includes determining the number of pages, generating correct slugs for each page, and passing pagination context through the rendering pipeline. (`src/Site.zig`) [[1]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R66-R77) [[2]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R363-R437) [[3]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935L336-R488) [[4]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R527-R539) [[5]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935L424-R574) [[6]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935L447-R602) [[7]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R723-R725) [[8]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R750-R752) [[9]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R781-R783) [[10]](diffhunk://#diff-0a79370350c3bc759aecc88a643bf5ea2f0e79dc36bb2d1c2bd8f4bb2e8ba935R821-R839)

**Dependency Update:**

- Updated the `httpz` dependency to a newer version compatible with Zig 0.14. (`build.zig.zon`)